### PR TITLE
Update 03-todo-app-dynamodb.rst: Missing step

### DIFF
--- a/docs/source/part1/03-todo-app-dynamodb.rst
+++ b/docs/source/part1/03-todo-app-dynamodb.rst
@@ -132,6 +132,11 @@ class.
                 )
             return _DB
 
+3. Go to the top of the ``app.py`` file. Modify the line ``from chalicelib.db import InMemoryTodoDB`` to reference ``db`` instead:
+ 
+    .. code-block:: python
+
+        from chalicelib import db
 
 Verification
 ~~~~~~~~~~~~


### PR DESCRIPTION
Add missing step which led to bug "NameError: global name 'db' is not defined" in Oct 25 2017 workshop at AWS pop up loft in SF.