### PR TITLE
fix missing pip install option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Building the Docs
 
 Install requirements::
 
-    $ pip install requirements.txt
+    $ pip install -r requirements.txt
 
 
 Build html docs::


### PR DESCRIPTION
pip install command was missing `-r` option to install from the given requirements file

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
